### PR TITLE
fix fsf address on license header

### DIFF
--- a/src/osdep/airpcap.c
+++ b/src/osdep/airpcap.c
@@ -28,7 +28,7 @@
    * do not wish to do so, delete this exception statement from your
    * version.  If you delete this exception statement from all source
    * files in the program, then also delete it here.
-   *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
    */
 #ifdef HAVE_AIRPCAP
 

--- a/src/osdep/byteorder.h
+++ b/src/osdep/byteorder.h
@@ -15,7 +15,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  *
  *
  *  In addition, as a special exception, the copyright holders give

--- a/src/osdep/common.c
+++ b/src/osdep/common.c
@@ -15,7 +15,7 @@
    *
    *  You should have received a copy of the GNU General Public License
    *  along with this program; if not, write to the Free Software
-   *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
    */
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/osdep/cygwin.c
+++ b/src/osdep/cygwin.c
@@ -16,7 +16,7 @@
    *
    *  You should have received a copy of the GNU General Public License
    *  along with this program; if not, write to the Free Software
-   *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
    */
 
 #include <pthread.h>

--- a/src/osdep/cygwin.h
+++ b/src/osdep/cygwin.h
@@ -16,7 +16,7 @@
    *
    *  You should have received a copy of the GNU General Public License
    *  along with this program; if not, write to the Free Software
-   *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
    */
 
 // DLL function that have to be exported

--- a/src/osdep/cygwin_tap.c
+++ b/src/osdep/cygwin_tap.c
@@ -15,7 +15,7 @@
    *
    *  You should have received a copy of the GNU General Public License
    *  along with this program; if not, write to the Free Software
-   *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <stdlib.h>

--- a/src/osdep/darwin.c
+++ b/src/osdep/darwin.c
@@ -16,7 +16,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <errno.h>

--- a/src/osdep/darwin_tap.c
+++ b/src/osdep/darwin_tap.c
@@ -16,7 +16,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/dummy.c
+++ b/src/osdep/dummy.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <errno.h>

--- a/src/osdep/dummy_tap.c
+++ b/src/osdep/dummy_tap.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <stdio.h>

--- a/src/osdep/file.c
+++ b/src/osdep/file.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/freebsd.c
+++ b/src/osdep/freebsd.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/endian.h>

--- a/src/osdep/freebsd_tap.c
+++ b/src/osdep/freebsd_tap.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 

--- a/src/osdep/linux.c
+++ b/src/osdep/linux.c
@@ -16,7 +16,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
 #include <sys/socket.h>

--- a/src/osdep/linux_tap.c
+++ b/src/osdep/linux_tap.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/socket.h>

--- a/src/osdep/netbsd.c
+++ b/src/osdep/netbsd.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/netbsd_tap.c
+++ b/src/osdep/netbsd_tap.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/network.c
+++ b/src/osdep/network.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/openbsd.c
+++ b/src/osdep/openbsd.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 #include <sys/types.h>
 #include <sys/endian.h>

--- a/src/osdep/openbsd_tap.c
+++ b/src/osdep/openbsd_tap.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/osdep.c
+++ b/src/osdep/osdep.c
@@ -15,7 +15,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <stdlib.h>

--- a/src/osdep/radiotap/radiotap-parser.c
+++ b/src/osdep/radiotap/radiotap-parser.c
@@ -13,7 +13,7 @@
   *
   *  You should have received a copy of the GNU General Public License
   *  along with this program; if not, write to the Free Software
-  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
   */
 
 #include <sys/types.h>

--- a/src/osdep/tap-win32/common.h
+++ b/src/osdep/tap-win32/common.h
@@ -23,7 +23,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program (see the file COPYING included with this
  *  distribution); if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
 //===============================================


### PR DESCRIPTION
This is a patch we apply on mdk3 on Debian, i'm packaging mdk4 for Debian and noticed that this fix was not on mdk4.

Thanks