### PR TITLE
[makefile] don't build if or libosdep.a is not finished

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ att:
 osd:
 	$(MAKE) -C $(OSD)
 
-$(LIBOSD):
+$(LIBOSD) $(OSD)/libosdep.a:
 	$(MAKE) -C $(OSD)
 
 $(OBJ_ATT):


### PR DESCRIPTION
Hello,

While packaging mdk4 for Debian I decided to upstream the patches that are being applied on Kali.

Thanks,