### PR TITLE
[Makefile] Fix regression from previous commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ all: clean
 	$(MAKE) -C $(SRC)
 
 install: all
-        PREFIX=$(DESTDIR)$(PREFIX) $(MAKE) -C $(SRC) install
-        install -D -m 0644 man/mdk4.1 $(DESTDIR)$(MANDIR)/man8/mdk4.1
-        gzip -f $(DESTDIR)$(MANDIR)/man8/mdk4.1
+	PREFIX:=$(DESTDIR)$(PREFIX) $(MAKE) -C $(SRC) install
+	install -D -m 0644 man/mdk4.1 $(DESTDIR)$(MANDIR)/man8/mdk4.1
+	gzip -f $(DESTDIR)$(MANDIR)/man8/mdk4.1
 
 .PHONY : clean
 clean:


### PR DESCRIPTION
Hello, PR https://github.com/aircrack-ng/mdk4/pull/14 introduced some problems that were detected while packaging a snapshot of mdk4 on Debian:

Don't create recursion problem with PREFIX variable definition by using ":=" and use tabs.

After this patch the build goes fine again.