### PR TITLE
[makefile] Respect and use {CPP|LD}FLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,10 +33,10 @@ $(OBJ_ATT):
 
 mdk4: mdk4.c $(OSD)/libosdep.a $(OBJS) $(OBJS_OSD) $(OBJ_ATT)
 	$(MAKE) -C $(ATTACKS)
-	$(CC) $(CFLAGS) $(^) -o $(@) $(LIBS) $(LINKFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(^) -o $(@) $(LIBS) $(LINKFLAGS)
 
 test: test.c $(OBJS)
-	$(CC) $(CFLAGS) $(^) -o $(@) $(LINKFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(^) -o $(@) $(LINKFLAGS)
 	mv $(@) ..
 
 install: mdk4

--- a/src/attacks/Makefile
+++ b/src/attacks/Makefile
@@ -1,5 +1,5 @@
-CFLAGS		= -g -O3 -Wall -Wextra
-LINKFLAGS	= -lpthread
+CFLAGS		+= -g -O3 -Wall -Wextra
+LINKFLAGS	= -lpthread $(LDFLAGS)
 
 OBJS		= $(shell ls *.h | sed s/"\.h"/"\.o"/g)
 


### PR DESCRIPTION
I noticed on Debian that some FLAGS weren't being used properly, thus affecting hardening.

Thanks.