### PR TITLE
Add include of stdlib.h

### DIFF
--- a/src/attacks/attacks.c
+++ b/src/attacks/attacks.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <string.h>
 
 #include "attacks.h"

--- a/src/attacks/dummy.c
+++ b/src/attacks/dummy.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
 When compiling with "-Wimplicit-function-declaration"
 on Debian, I noticed a bunch of warnings like:
 warning: implicit declaration of function ‘malloc’