### PR TITLE
Remove unused variables

### DIFF
--- a/src/attacks/probing.c
+++ b/src/attacks/probing.c
@@ -192,7 +192,7 @@ unsigned int get_ssid_len(struct ether_addr target) {
 struct packet create_probe_req(struct probing_options *popt)
 {
   struct packet probe;
-  unsigned char i,c,type, ssid_len;
+  unsigned char i,c,type;
   unsigned char ssid[256] = {0};
   struct ether_addr apmac = *(popt->target);
   struct ether_addr stamac = generate_mac(MAC_KIND_RANDOM);

--- a/src/channelhopper.c
+++ b/src/channelhopper.c
@@ -384,7 +384,6 @@ void channel_sniff()
 	struct ieee_hdr *hdr;
 	struct ether_addr bssid;
 	char ssid[32];
-	int ie_type;
 	int ie_len;
 	unsigned char *pie_data;
 	unsigned char channel;
@@ -589,7 +588,7 @@ void init_channel_hopper(char *chanlist, int useconds)
     // Channel list chans[MAX_CHAN_COUNT] has been initialized with declaration for all b/g channels
     char *token = NULL;
     int chan_cur = EOF;
-    int lpos = 0, i;
+    int lpos = 0;
 
     if (hopper) {
       printf("There is already a channel hopper running, skipping this one!\n");


### PR DESCRIPTION
 When compiling with "-Wunused-variable"
 on Debian, I noticed a bunch of warnings like:
 warning: unused variable ‘SOMETHING’