### PR TITLE
Recommend using clang as compiler for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ MDK4 is licenced under the GPLv2 or later.
 		cd mdk4
 		make
 		sudo make install
+		# Using Arch Linux (and derived) append: CC=clang
 
 
 # Features

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MDK4 is licenced under the GPLv2 or later.
 		cd mdk4
 		make
 		sudo make install
-		# Using Arch Linux (and derived) append: CC=clang
+		# Using Arch Linux (and derived) append `CC=clang` after any `make` in commands. 
 
 
 # Features


### PR DESCRIPTION
# Summary
Recommend using clang as compiler for Arch Linux or derived distros for installing from source code.

Closes #51 