### PR TITLE
src/Makefile: Fix parallel build race in osdep

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,8 +27,7 @@ att:
 osd:
 	$(MAKE) -C $(OSD)
 
-$(LIBOSD) $(OSD)/libosdep.a:
-	$(MAKE) -C $(OSD)
+$(LIBOSD) $(OSD)/libosdep.a: osd
 
 $(OBJ_ATT):
 	$(MAKE) -C $(ATTACKS)


### PR DESCRIPTION
Building the same thing more than once in parallel is not only
inefficient but can also break the build.

```
https://tests.reproducible-builds.org/debian/rbuild/unstable/armhf/mdk4_4.2-2.rbuild.log.gz
...
ar cru libosdep.a  osdep.o network.o file.o linux.o linux_tap.o radiotap/radiotap.o common.o
ar cru libosdep.a  osdep.o network.o file.o linux.o linux_tap.o radiotap/radiotap.o common.o
ar: `u' modifier ignored since `D' is the default (see `U')
ar: `u' modifier ignored since `D' is the default (see `U')
ranlib libosdep.a
ranlib libosdep.a
ranlib: libosdep.a: error reading linux.o: file truncated
make[4]: *** [Makefile:62: .os.Linux] Error 1
```