### PR TITLE
Fix wrong man section

### DIFF
--- a/man/mdk4.8
+++ b/man/mdk4.8
@@ -1,4 +1,4 @@
-.TH MDK4 2 "July 2021" "mdk4 v2"
+.TH MDK4 8 "July 2021" "mdk4 v2"
 
 .SH NAME
 mdk4 \- IEEE 802.11 PoC tool


### PR DESCRIPTION
Man file is in section 8 (System Manager's Manual), but when user opens man, user sees it in section 2 (System Calls Manual).

This is wrong and confusing. This pull request changes man section inside man file to 8.