### PR TITLE
Declare functions before using it

### DIFF
--- a/src/attacks/poc.c
+++ b/src/attacks/poc.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <dirent.h>
 #include <pthread.h>
+#include <ctype.h>
 
 #include "poc.h"
 
@@ -16,6 +17,9 @@
 
 struct poc_packet *poc_pkts = NULL;
 int vendor_cnt = 0;
+
+int get_file_lines(char * filename);
+int str_to_hex(unsigned char *pascii, unsigned char *phex, unsigned int len);
 
 void poc_shorthelp()
 {

--- a/src/greylist.c
+++ b/src/greylist.c
@@ -10,13 +10,6 @@ struct greylist {
   struct greylist *next;
 };
 
-typedef enum
-{
-  BLACK_LIST,
-  WHITE_LIST,
-
-}list_type;
-
 struct greylist *glist = NULL;
 struct greylist *blist = NULL;
 struct greylist *wlist = NULL;
@@ -58,7 +51,7 @@ struct greylist *search_in_greylist(struct ether_addr mac, struct greylist *gl) 
   return NULL;
 }
 
-void load_greylist(list_type type, char *filename) {
+void load_greylist(greylist_type type, char *filename) {
   char *entry;
 
   if (filename) {

--- a/src/greylist.h
+++ b/src/greylist.h
@@ -14,4 +14,13 @@ char is_blacklisted(struct ether_addr mac);
 
 char is_whitelisted(struct ether_addr mac);
 
+typedef enum
+{
+  BLACK_LIST,
+  WHITE_LIST,
+
+}greylist_type;
+
+void load_greylist(greylist_type type, char *filename);
+
 #endif

--- a/src/packet.h
+++ b/src/packet.h
@@ -266,4 +266,7 @@ void set_seqno(struct packet *pkt, uint16_t seqno);
 uint8_t get_fragno(struct packet *pkt);
 void set_fragno(struct packet *pkt, uint8_t frag, int last_frag);
 
+void add_ssid_set(struct packet *pkt, char *ssid);
+void add_rate_sets(struct packet *pkt, char b_rates, char g_rates);
+
 #endif


### PR DESCRIPTION
Lately Debian enabled -Werror=implicit-function-declaration, causing the build to break in a few places. Fix it by declaring functions before using it, or including the right libraries.

Errors that this commit fixes are:

```
probing.c:236:3: error: implicit declaration of function ‘add_ssid_set’ [-Werror=implicit-function-declaration]
probing.c:237:3: error: implicit declaration of function ‘add_rate_sets’ [-Werror=implicit-function-declaration]
poc.c:152:30: error: implicit declaration of function ‘get_file_lines’ [-Werror=implicit-function-declaration]
poc.c:169:59: error: implicit declaration of function ‘str_to_hex’ [-Werror=implicit-function-declaration]
poc.c:522:30: error: implicit declaration of function ‘toupper’ [-Werror=implicit-function-declaration]
test.c:164:3: error: implicit declaration of function ‘load_greylist’; did you mean ‘test_greylist’? [-Werror=implicit-function-declaration]
```