### PR TITLE
add country information to beacon attack

### DIFF
--- a/src/attacks/beacon_flood.c
+++ b/src/attacks/beacon_flood.c
@@ -27,6 +27,7 @@ struct beacon_flood_options {
   unsigned int speed;
   unsigned char *ies;
   int ies_len;
+  char *country;
 };
 
 //Global things, shared by packet creation and stats printing
@@ -49,6 +50,8 @@ void beacon_flood_longhelp()
 	  "      -a\n"
 	  "         Use also non-printable caracters in generated SSIDs\n"
 	  "         and create SSIDs that break the 32-byte limit\n"
+	  "      -C <country>\n"
+	  "         Country code\n"
 	  "      -f <filename>\n"
 	  "         Read SSIDs from file\n"
 	  "      -v <filename>\n"
@@ -98,8 +101,9 @@ void *beacon_flood_parse(int argc, char *argv[]) {
   bopt->speed = 50;
   bopt->ies = NULL;
   bopt->ies_len = 0;
+  bopt->country = NULL;
 
-  while ((opt = getopt(argc, argv, "n:f:av:t:w:b:mhc:s:i:")) != -1) {
+  while ((opt = getopt(argc, argv, "n:f:av:t:w:b:mhc:s:i:C:")) != -1) {
     switch (opt) {
       case 'n':
 	if (strlen(optarg) > 255) {
@@ -164,6 +168,12 @@ void *beacon_flood_parse(int argc, char *argv[]) {
       break;
       case 'i':
 	bopt->ies = hex2bin(optarg, &(bopt->ies_len));
+      break;
+      case 'C':
+	if (strlen(optarg) > 2) {
+	  printf("ERROR: country code too long\n"); return NULL;
+	}
+	bopt->country = malloc(strlen(optarg)); strcpy(bopt->country, optarg);
       break;
       default:
 	beacon_flood_longhelp();
@@ -245,6 +255,7 @@ struct packet beacon_flood_getpacket(void *options) {
   }
 
   pkt = create_beacon(bssid, ssid, (uint8_t) curchan, bopt->encryptions[encindex], bitrate, adhoc);
+  if (bopt->country) add_country_set(&pkt, bopt->country);
   if (bopt->ies) append_data(&pkt, bopt->ies, bopt->ies_len);
 
   sleep_till_next_packet(bopt->speed);

--- a/src/packet.c
+++ b/src/packet.c
@@ -159,6 +159,17 @@ void add_channel_set(struct packet *pkt, uint8_t channel) {
   pkt->len += 3;
 }
 
+void add_country_set(struct packet *pkt, char *country) {
+  pkt->data[pkt->len] = 0x07;	// Country Information set
+  pkt->data[pkt->len+1] = 0x06;	// length
+  memcpy(pkt->data + pkt->len + 2, country, 2);	// copy country code
+  pkt->data[pkt->len+4] = ' '; // environment: ' ' for any. 'I' for indoor. 'O' for outdoor
+  pkt->data[pkt->len+5] = 1; // first channel
+  pkt->data[pkt->len+6] = 13; // number of channel
+  pkt->data[pkt->len+7] = 30; // max tx power
+  pkt->len += 8;
+}
+
 struct packet create_beacon(struct ether_addr bssid, char *ssid, uint8_t channel, char encryption, unsigned char bitrate, char adhoc) {
   struct packet beacon = {0};
   struct beacon_fixed *bf;

--- a/src/packet.h
+++ b/src/packet.h
@@ -251,6 +251,9 @@ uint16_t get_capabilities(struct packet *pkt);
 //Append data to packet
 void append_data(struct packet *pkt, unsigned char *data, int len);
 
+//Append country code to packet
+void add_country_set(struct packet *pkt, char *country);
+
 //Adds LLC header to a packet created with create_ieee_hdr(). You can use this to build unencrypted data frames or EAP packets.
 void add_llc_header(struct packet *pkt, uint16_t llc_type);
 


### PR DESCRIPTION
intel wireless adapter will try set country code of itself by watching most common used (i guess) country in beacon frame from other ap (aka location aware regulatory, or https://en.wikipedia.org/wiki/IEEE_802.11d-2001).

add a new country parameter to beacon flood. so that user can mimic their country easily